### PR TITLE
Late JS enqueuing

### DIFF
--- a/admin/ucf-charts-config.php
+++ b/admin/ucf-charts-config.php
@@ -145,13 +145,13 @@ if ( ! class_exists( 'UCF_Chart_Config' ) ) {
 
 			add_settings_field(
 				self::$option_prefix . 'include_js',
-				'Include default JS',
+				'Include default JS dependencies',
 				array( 'UCF_Chart_Config', 'display_settings_field' ),
 				'ucf_chart',
 				'ucf_chart_section_assets',
 				array(
 					'label_for'   => self::$option_prefix . 'include_js',
-					'description' => 'When checked the included default JS will be enqueued on all pages. (Note: You must initiate all charts manually in your theme javascript file if this is unchecked).',
+					'description' => 'When checked, ChartJS and the plugin\'s included default Javascript will be enqueued on all pages that include a chart. (Note: You must include the ChartJS library and initiate all charts manually in your theme or another plugin if this is unchecked).',
 					'type'        => 'checkbox'
 				)
 			);

--- a/admin/ucf-charts-config.php
+++ b/admin/ucf-charts-config.php
@@ -151,7 +151,7 @@ if ( ! class_exists( 'UCF_Chart_Config' ) ) {
 				'ucf_chart_section_assets',
 				array(
 					'label_for'   => self::$option_prefix . 'include_js',
-					'description' => 'When checked, ChartJS and the plugin\'s included default Javascript will be enqueued on all pages that include a chart. (Note: You must include the ChartJS library and initiate all charts manually in your theme or another plugin if this is unchecked).',
+					'description' => 'When checked, ChartJS and the plugin\'s included default Javascript will be enqueued on all pages that include a chart. (Note: If unchecked, you must include the ChartJS library and initiate all charts manually in your theme or another plugin).',
 					'type'        => 'checkbox'
 				)
 			);

--- a/includes/ucf-charts-common.php
+++ b/includes/ucf-charts-common.php
@@ -27,28 +27,31 @@ if ( ! class_exists( 'UCF_Chart_Common' ) ) {
 		}
 
 		/**
-		 * Handles enqueuing frontend assets
+		 * Handles registering frontend assets
 		 * @author Jim Barnes
 		 * @since 1.0.0
 		 **/
-		public static function enqueue_frontend_assets() {
+		public static function register_frontend_assets() {
 			if ( UCF_Chart_Config::get_option_or_default( 'include_js' ) ) {
-				wp_enqueue_script(
+				$plugin_data    = get_plugin_data( UCF_CHARTS__PLUGIN_FILE, false, false );
+				$plugin_version = $plugin_data['Version'];
+
+				wp_register_script(
 					'chart-js',
 					UCF_CHARTS__VENDOR_JS_URL,
 					array( 'jquery' ),
 					null,
 					True
 				);
-			}
 
-			wp_enqueue_script(
-				'ucf-chart',
-				UCF_CHARTS__JS_URL . '/ucf-chart.min.js',
-				array( 'jquery', 'chart-js' ),
-				null,
-				True
-			);
+				wp_register_script(
+					'ucf-chart',
+					UCF_CHARTS__JS_URL . '/ucf-chart.min.js',
+					array( 'jquery', 'chart-js' ),
+					$plugin_version,
+					True
+				);
+			}
 		}
 
 		/**

--- a/shortcodes/ucf-charts-shortcode.php
+++ b/shortcodes/ucf-charts-shortcode.php
@@ -69,6 +69,12 @@ if ( ! class_exists( 'UCF_Chart_Shortcode' ) ) {
 
 				$args_string = implode( $flattened );
 
+				// Enqueue JS late (to avoid including these scripts on every page)
+				if ( UCF_Chart_Config::get_option_or_default( 'include_js' ) ) {
+					wp_enqueue_script( 'chart-js' );
+					wp_enqueue_script( 'ucf-chart' );
+				}
+
 				ob_start();
 			?>
 				<div <?php echo $args_string; ?>></div>

--- a/ucf-charts-plugin.php
+++ b/ucf-charts-plugin.php
@@ -55,8 +55,8 @@ if ( ! function_exists( 'ucf_charts_init' ) ) {
 		/* Add custom column */
 		add_action( 'manage_ucf_chart_posts_columns', array( 'UCF_Chart_Admin', 'ucf_chart_custom_columns' ), 10, 1 );
 		add_action( 'manage_posts_custom_column', array( 'UCF_Chart_Admin', 'ucf_chart_shortcode_column' ), 10, 2 );
-		/* Enqueue frontend assets */
-		add_action( 'wp_enqueue_scripts', array( 'UCF_Chart_Common', 'enqueue_frontend_assets' ), 10, 0 );
+		/* Register frontend assets */
+		add_action( 'wp_enqueue_scripts', array( 'UCF_Chart_Common', 'register_frontend_assets' ), 10, 0 );
 		/* Add shortcode */
         add_action( 'init', array( 'UCF_Chart_Shortcode', 'register' ), 10, 0 );
         /* Add hook to allow for json uploads */


### PR DESCRIPTION
Updated how javascript assets are registered and enqueued in this plugin.  Since this plugin's static assets can all be included independently at the bottom of the document, we can get away with registering frontend assets early, then enqueuing them late on shortcode output, ensuring that this plugin's JS is only included on pages that need it.

The field name/description for the 'Include Default JS' field have also been updated for clarity and to better reflect the updated inclusion logic in `register_frontend_assets()`.